### PR TITLE
Standardize API key usage to GOOGLE_API_KEY only; remove GEMINI_API_K…

### DIFF
--- a/insight/detector.py
+++ b/insight/detector.py
@@ -15,7 +15,7 @@ def show_error(message):
             title_align="left"
         )
     )
-api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+api_key = os.environ.get("GOOGLE_API_KEY")
 if not api_key:
     error_message = '''❌ Error: Missing Google API Key / Application Issue
 It looks like the application encountered an issue, possibly due to a missing Google API key.


### PR DESCRIPTION
### 🚀 What does this PR do?
- Standardizes API key usage by removing the `GEMINI_API_KEY` environment variable in favor of only using `GOOGLE_API_KEY`.
- Updates error messages and documentation to reflect this change.
- Simplifies configuration and reduces confusion around API keys.

### 📝 Issue Reference:
Fixes issue: #7 

### 🔍 Checklist:
- [x] Changed `detector.py` to only use `GOOGLE_API_KEY`.
- [x] Updated error messages accordingly.
- [x] Verified no other files reference `GEMINI_API_KEY`.
- [x] Tested that the application exits gracefully when `GOOGLE_API_KEY` is missing.

### 🌟 Additional Notes:
This PR improves consistency in environment variable usage and aligns with official Google API key naming conventions.
