### PR TITLE
fix: Log AST parsing errors in analyzer

### DIFF
--- a/insight/analyzer.py
+++ b/insight/analyzer.py
@@ -1,5 +1,6 @@
 import ast
 import os
+import logging
 from .detector import explain_code
 from .utils import list_source_files
 
@@ -25,8 +26,8 @@ def extract_code_stats(file_path, content):
                     stats["imports"].extend(alias.name for alias in node.names)
                 elif isinstance(node, ast.ImportFrom):
                     stats["imports"].append(node.module)
-        except Exception:
-            pass
+        except Exception as e:
+            logging.warning(f"Could not parse {file_path}: {e}")
 
     return stats
 


### PR DESCRIPTION
Changes

   * Modified insight/analyzer.py to log a warning on AST parsing errors.
   * Added import logging to insight/analyzer.py.
   Fixes #9 